### PR TITLE
📚 docs(readme): add Stanford convex optimization course references (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 - Chong, E. K., Lu, W. S., & Zak, S. H. (2023). An introduction to optimization: With applications to machine learning. John Wiley & Sons.
 - Boyd, S., & Vandenberghe, L. (2004). Convex optimization. Cambridge university press.
+- Stanford Engineering Everywhere | Convex Optimization [cvxopt-I], [cvxopt-II]
+
+cvxopt-I: https://see.stanford.edu/Course/EE364A
+cvxopt-II: https://see.stanford.edu/Course/EE364B
 
 ## Linear Algebra
 


### PR DESCRIPTION
Document Stanford SEE convex optimization courses EE364A and EE364B in the references section, including direct links to both course pages for easier access by readers.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
