### PR TITLE
📝 fix(readme): correct markdown reference link syntax (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 - Boyd, S., & Vandenberghe, L. (2004). Convex optimization. Cambridge university press.
 - Stanford Engineering Everywhere | Convex Optimization [cvxopt-I], [cvxopt-II]
 
-cvxopt-I: https://see.stanford.edu/Course/EE364A
-cvxopt-II: https://see.stanford.edu/Course/EE364B
+[cvxopt-I]: https://see.stanford.edu/Course/EE364A
+[cvxopt-II]: https://see.stanford.edu/Course/EE364B
 
 ## Linear Algebra
 


### PR DESCRIPTION
Update README to use proper reference-style link definitions for cvxopt-I and cvxopt-II, ensuring links render correctly and improving Markdown consistency.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
