### PR TITLE
📚 docs(readme): add dynamic programming reference to bibliography (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@
 - Dantzig, G. B. (1956). Constructive proof of the Min-Max theorem. [Paper](dantzig-paper)
 
 [dantzig-paper]: https://projecteuclid.org/journals/pacific-journal-of-mathematics/volume-6/issue-1/Constructive-proof-of-the-Min-Max-theorem/pjm/1103044237.pdf
+
+## Dynamic Programming
+
+- Bellman, R. (1966). Dynamic programming. science, 153(3731), 34-37.


### PR DESCRIPTION
Add a new Dynamic Programming section to the README, citing Bellman’s 1966 paper, to expand the list of foundational optimization references and improve documentation completeness.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
