### PR TITLE
✨ docs(readme): add Probability section with Kelly criterion reference (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 - [Linear Algebra for Programmers](https://www.linearalgebraforprogrammers.com/)
 
+## Probability
+
+- Thorp, E. O. (2011). Understanding the Kelly criterion. In The Kelly capital growth investment criterion: theory and practice (pp. 509-523).
+
 ## Mathematical Statistics
 
 - Hogg, R. V., McKean, J. W., & Craig, A. T. (2013). Introduction to mathematical statistics. Pearson Education India.


### PR DESCRIPTION
Adds a new Probability heading and includes a bibliographic citation to Thorp’s 2011 work on the Kelly criterion to expand learning resources.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
