### PR TITLE
📚 docs(readme): add Chung (1974) probability reference (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 ## Probability
 
+- Chung, K. L. (1974). A course in probability theory. Probability and mathematical statistics.
 - Thorp, E. O. (2011). Understanding the Kelly criterion. In The Kelly capital growth investment criterion: theory and practice (pp. 509-523).
 
 ## Mathematical Statistics


### PR DESCRIPTION
Adds a new bibliography entry under the Probability section, citing K. L. Chung’s 1974 textbook to complement existing references.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
