### PR TITLE
📚 docs(readme): add Measure and Integral reference (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## Analysis
 
 - Rudin, W. (1964). Principles of mathematical analysis.
+- Wheeden, R. L., & Zygmund, A. (1977). Measure and integral (Vol. 26). New York: Dekker.
 
 ## Probability
 


### PR DESCRIPTION
Added Wheeden and Zygmund (1977) citation to the Analysis section bibliography in README, expanding recommended resources for measure theory and integration topics.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
