### PR TITLE
🐛 fix(readme): correct optimization heading (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # References
 
-## Convex Optimization
+## Optimization
 
 - Chong, E. K., Lu, W. S., & Zak, S. H. (2023). An introduction to optimization: With applications to machine learning. John Wiley & Sons.
 - Boyd, S., & Vandenberghe, L. (2004). Convex optimization. Cambridge university press.


### PR DESCRIPTION
Rename the README section header from “Convex Optimization” to “Optimization” to better reflect the referenced materials and avoid misleading categorization.

Signed-off-by: Mao-Kai Lan <45162039+mukappalambda@users.noreply.github.com>
